### PR TITLE
Fixing compilation for wasm32 targets

### DIFF
--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -1,0 +1,47 @@
+on: [push]
+
+name: wasm32 builds
+
+jobs:
+  wasm32-unknown-unknown:
+    name: wasm32-unknown-unknown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target wasm32-unknown-unknown
+  wasm32-wasi:
+    name: wasm32-wasi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Install wasm32-wasi target
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-wasi
+      - name: Install wasmtime
+        run: "curl https://wasmtime.dev/install.sh -sSf | bash"
+      - name: Add wasmtime to PATH
+        run: echo "::add-path::$HOME/.wasmtime/bin"
+      - name: Install cargo-wasi command
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --force cargo-wasi
+      - name: Build code with cargo-wasi
+        uses: actions-rs/cargo@v1
+        with:
+          command: wasi
+          args: build
+      - name: Run tests under wasm32-wasi
+        uses: actions-rs/cargo@v1
+        with:
+          command: wasi
+          args: test

--- a/src/bit_vec/bit_vector.rs
+++ b/src/bit_vec/bit_vector.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 #[cfg(target_pointer_width = "32")]
-use num::ToPrimitive;
+use num_traits::ToPrimitive;
 
 use internal::vector_base::{VectorBase, self};
 use space_usage::SpaceUsage;

--- a/src/internal/vector_base.rs
+++ b/src/internal/vector_base.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 #[cfg(target_pointer_width = "32")]
-use num::ToPrimitive;
+use num_traits::ToPrimitive;
 
 use bit_vec::{BitVec, BitVecMut};
 use space_usage::SpaceUsage;
@@ -396,6 +396,14 @@ impl<'a, Block: BlockType> Iterator for Iter<'a, Block> {
 }
 
 #[cfg(target_pointer_width = "64")]
+impl<'a, Block: BlockType> ExactSizeIterator for Iter<'a, Block> {
+    #[inline]
+    fn len(&self) -> usize {
+        (self.limit - self.start) as usize
+    }
+}
+
+#[cfg(target_pointer_width = "32")]
 impl<'a, Block: BlockType> ExactSizeIterator for Iter<'a, Block> {
     #[inline]
     fn len(&self) -> usize {

--- a/src/rank/rank9.rs
+++ b/src/rank/rank9.rs
@@ -26,6 +26,7 @@ struct Level2(u64);
 impl Level2 {
     fn new() -> Self { Level2(0) }
 
+    #[cfg(target_pointer_width = "64")]
     fn get(&self, t: usize) -> u64 {
         debug_assert!(t < 8);
 
@@ -34,11 +35,34 @@ impl Level2 {
         self.0 >> shift & 0x1FF
     }
 
+    #[cfg(target_pointer_width = "64")]
     fn set(&mut self, t: usize, value: u64) {
         debug_assert!(t < 8);
 
         let t = t.wrapping_sub(1);
         let shift = t.wrapping_add(t >> 60 & 8) * 9;
+
+        let old_part = self.0 & !(0x1FF << shift);
+        let new_part = (value & 0x1FF) << shift;
+
+        self.0 = old_part | new_part;
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    fn get(&self, t: usize) -> u64 {
+        debug_assert!(t < 8);
+
+        let t = t.wrapping_sub(1);
+        let shift = t.wrapping_add(t >> 28 & 8) * 9;
+        self.0 >> shift & 0x1FF
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    fn set(&mut self, t: usize, value: u64) {
+        debug_assert!(t < 8);
+
+        let t = t.wrapping_sub(1);
+        let shift = t.wrapping_add(t >> 28 & 8) * 9;
 
         let old_part = self.0 & !(0x1FF << shift);
         let new_part = (value & 0x1FF) << shift;


### PR DESCRIPTION
Trying to fix succinct-rs to run in wasm32 (since it's a transitive dependency for me, I'm using pdatastructs.rs). As the name implies, wasm32 is 32-bit and some implementations are missing (where checks for 64-bit pointer size were used).

This is a WIP just doing the bare minimum to make it compile and pass the current tests, but still need to write more tests for 32-bit cases.